### PR TITLE
drivers: Makefile: probing i2c after clk init

### DIFF
--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -5,6 +5,9 @@
 # Rewritten to use lists instead of if-statements.
 #
 
+#common clk code
+obj-y				+= clk/
+
 obj-y				+= irqchip/
 obj-y				+= bus/
 
@@ -137,8 +140,6 @@ obj-$(CONFIG_VHOST_RING)	+= vhost/
 obj-$(CONFIG_VLYNQ)		+= vlynq/
 obj-$(CONFIG_STAGING)		+= staging/
 obj-y				+= platform/
-#common clk code
-obj-y				+= clk/
 
 obj-$(CONFIG_MAILBOX)		+= mailbox/
 obj-$(CONFIG_HWSPINLOCK)	+= hwspinlock/


### PR DESCRIPTION
clk inits after probing i2c, so that i2c failed to get clk. 

[    0.288049] i2c-msm-v2 f9924000.i2c: probing driver i2c-msm-v2
[    0.288602] i2c-msm-v2 f9967000.i2c: error on clk_get(core_clk):-517
[    0.288612] i2c-msm-v2 f9967000.i2c: error probe() failed with err:-517

Just move clk upto a higher position than i2c.
no more this error message disappears