### PR TITLE
drivers: i2c: probing i2c initcall delay (v2)

### DIFF
--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -5,9 +5,6 @@
 # Rewritten to use lists instead of if-statements.
 #
 
-#common clk code
-obj-y				+= clk/
-
 obj-y				+= irqchip/
 obj-y				+= bus/
 
@@ -140,6 +137,8 @@ obj-$(CONFIG_VHOST_RING)	+= vhost/
 obj-$(CONFIG_VLYNQ)		+= vlynq/
 obj-$(CONFIG_STAGING)		+= staging/
 obj-y				+= platform/
+#common clk code
+obj-y				+= clk/
 
 obj-$(CONFIG_MAILBOX)		+= mailbox/
 obj-$(CONFIG_HWSPINLOCK)	+= hwspinlock/

--- a/drivers/i2c/busses/i2c-msm-v2.c
+++ b/drivers/i2c/busses/i2c-msm-v2.c
@@ -2976,7 +2976,7 @@ static int i2c_msm_init(void)
 {
 	return platform_driver_register(&i2c_msm_driver);
 }
-arch_initcall(i2c_msm_init);
+subsys_initcall(i2c_msm_init);
 
 static void i2c_msm_exit(void)
 {

--- a/drivers/spmi/spmi-pmic-arb.c
+++ b/drivers/spmi/spmi-pmic-arb.c
@@ -1008,7 +1008,7 @@ spmi_pmic_arb_get_property(struct platform_device *pdev, char *pname, u32 *prop)
 	int ret = of_property_read_u32(pdev->dev.of_node, pname, prop);
 
 	if (ret)
-		dev_err(&pdev->dev, "missing property: %s\n", pname);
+		dev_dbg(&pdev->dev, "missing property: %s\n", pname);
 	else
 		pr_debug("%s = 0x%x\n", pname, *prop);
 
@@ -1104,7 +1104,7 @@ static int pmic_arb_version_specific_init(struct spmi_pmic_arb_dev *pmic_arb,
 	version = readl_relaxed(pmic_arb->base + PMIC_ARB_VERSION);
 
 	if (version < PMIC_ARB_V2_MIN) {
-		dev_err(&pdev->dev, "PMIC Arb Version-1 0x%x\n", version);
+		dev_dbg(&pdev->dev, "PMIC Arb Version-1 0x%x\n", version);
 		pmic_arb->rdbase	 = pmic_arb->base;
 		pmic_arb->wrbase	 = pmic_arb->base;
 		pmic_arb->dbg.rdbase_phy = pmic_arb->dbg.base_phy;


### PR DESCRIPTION
[    0.285977] i2c-msm-v2 f9963000.i2c: probing driver i2c-msm-v2
[    0.286048] i2c-msm-v2 f9963000.i2c: error on clk_get(core_clk):-517
[    0.286057] i2c-msm-v2 f9963000.i2c: error probe() failed with err:-517


test boot OK, no this message anymore 
have fun ;p
